### PR TITLE
Add color picker to theme settings

### DIFF
--- a/lib/components/settings/settings-item.jsx
+++ b/lib/components/settings/settings-item.jsx
@@ -28,6 +28,14 @@ export default function SettingsItem({
   onChange,
 }) {
   const onClick = (e) => Utils.clickEffect(e);
+  const textInputRef = React.useRef();
+
+  const onColorInputChange = (e) => {
+    onChange(e);
+    if (textInputRef.current) {
+      textInputRef.current.value = e.target.value;
+    }
+  };
   if (type === "component") {
     return <Component defaultValue={defaultValue} onChange={onChange} />;
   }
@@ -72,12 +80,21 @@ export default function SettingsItem({
       <React.Fragment>
         <label htmlFor={code} dangerouslySetInnerHTML={{ __html: label }} />
         {type === "color" && (
-          <div
-            className="settings__item-color-pill"
-            style={{ backgroundColor: defaultValue || "transparent" }}
-          />
+          <React.Fragment>
+            <input
+              type="color"
+              className="settings__item-color-picker"
+              value={defaultValue || "#000000"}
+              onChange={onColorInputChange}
+            />
+            <div
+              className="settings__item-color-pill"
+              style={{ backgroundColor: defaultValue || "transparent" }}
+            />
+          </React.Fragment>
         )}
         <input
+          ref={type === "color" ? textInputRef : undefined}
           id={code}
           type="text"
           defaultValue={defaultValue}

--- a/lib/styles/components/settings/settings.js
+++ b/lib/styles/components/settings/settings.js
@@ -213,6 +213,17 @@ export const settingsStyles = /* css */ `
 .settings__item--color > input {
   padding-left: 24px;
 }
+.settings__item-color-picker {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 16px;
+  height: 16px;
+  padding: 0;
+  border: 0;
+  opacity: 0;
+  cursor: pointer;
+}
 .settings__item-color-pill {
   position: absolute;
   bottom: 1px;


### PR DESCRIPTION
## Summary
- add overlay color picker input in settings-item when editing theme colors
- style color picker overlay

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.* file)*

------
https://chatgpt.com/codex/tasks/task_e_683fce6ed454832a98922930fcc0f45b